### PR TITLE
Rewrite uuid stuff

### DIFF
--- a/src/main/java/foundry/alembic/attribute/AlembicAttribute.java
+++ b/src/main/java/foundry/alembic/attribute/AlembicAttribute.java
@@ -2,6 +2,7 @@ package foundry.alembic.attribute;
 
 import dev.shadowsoffire.attributeslib.api.IFormattableAttribute;
 import foundry.alembic.stats.item.ItemStatManager;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,19 +22,19 @@ public class AlembicAttribute extends RangedAttribute implements IFormattableAtt
         cache.clear();
     }
 
-    public void setBaseValue(double value){
+    public void setBaseValue(double value) {
         this.defaultValue = value;
     }
 
-    public void setMinValue(double value){
+    public void setMinValue(double value) {
         this.minValue = value;
     }
 
-    public void setMaxValue(double value){
+    public void setMaxValue(double value) {
         this.maxValue = value;
     }
 
-    public void setDescriptionId(String id){
+    public void setDescriptionId(String id) {
         this.descriptionId = id;
     }
 
@@ -43,21 +44,6 @@ public class AlembicAttribute extends RangedAttribute implements IFormattableAtt
             return null;
         }
 
-        AtomicReference<UUID> uuid = new AtomicReference<>(null);
-        if (cache.containsKey(this)) {
-            uuid.set(cache.get(this));
-        } else {
-            ItemStatManager.getStats().values().forEach((itemStat) -> {
-                itemStat.asMap().values().forEach((itemModifier) -> {
-                    itemModifier.stream().findFirst().ifPresent(mod -> {
-                        mod.attributeData().stream().filter(att -> att.getAttribute() != null && att.getAttribute().equals(this)).findFirst().ifPresent(att -> {
-                            uuid.set(att.getUUID());
-                        });
-                    });
-                });
-            });
-            cache.put(this, uuid.get());
-        }
-        return uuid.get();
+        return UUIDManager.getOrCreate(BuiltInRegistries.ATTRIBUTE.getKey(this));
     }
 }

--- a/src/main/java/foundry/alembic/attribute/UUIDFactory.java
+++ b/src/main/java/foundry/alembic/attribute/UUIDFactory.java
@@ -1,0 +1,22 @@
+package foundry.alembic.attribute;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.UUID;
+
+//
+@ApiStatus.ScheduledForRemoval(inVersion = "1.21")
+@Deprecated(forRemoval = true)
+public interface UUIDFactory {
+    UUID getOrCreate(ResourceLocation id);
+
+    static UUID getOrCreate(Level level, ResourceLocation id) {
+        if (!level.isClientSide && UUIDSavedData.getOrLoad(level.getServer()).hasKey(id)) {
+            return UUIDSavedData.getOrLoad(level.getServer()).getOrCreate(id);
+        } else {
+            return UUIDManager.INSTANCE.getOrCreate(id);
+        }
+    }
+}

--- a/src/main/java/foundry/alembic/attribute/UUIDManager.java
+++ b/src/main/java/foundry/alembic/attribute/UUIDManager.java
@@ -1,0 +1,29 @@
+package foundry.alembic.attribute;
+
+import dev.shadowsoffire.attributeslib.AttributesLib;
+import dev.shadowsoffire.attributeslib.api.AttributeHelper;
+import net.minecraft.Util;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public final class UUIDManager {
+    private UUIDManager() {}
+    public static final UUIDFactory INSTANCE = UUIDManager::getOrCreate;
+    private static final Map<ResourceLocation, UUID> UUIDS = Util.make(new HashMap<>(), map -> {
+        map.put(new ResourceLocation("helmet"), UUID.fromString("2AD3F246-FEE1-4E67-B886-69FD380BB150"));
+        map.put(new ResourceLocation("chestplate"), UUID.fromString("9F3D476D-C118-4544-8365-64846904B48E"));
+        map.put(new ResourceLocation("leggings"), UUID.fromString("D8499B04-0E66-4726-AB29-64469D734E0D"));
+        map.put(new ResourceLocation("boots"), UUID.fromString("845DB27C-C624-495F-8C9F-6020A9A58B6B"));
+        map.put(new ResourceLocation("generic.attack_damage"), Item.BASE_ATTACK_DAMAGE_UUID);
+        map.put(new ResourceLocation("generic.attack_speed"), Item.BASE_ATTACK_SPEED_UUID);
+        map.put(new ResourceLocation("forge", "entity_reach"), AttributeHelper.BASE_ENTITY_REACH);
+    });
+
+    public static UUID getOrCreate(ResourceLocation id) {
+        return UUIDS.computeIfAbsent(id, resourceLocation -> UUID.nameUUIDFromBytes(id.toString().getBytes()));
+    }
+}

--- a/src/main/java/foundry/alembic/stats/item/ItemStat.java
+++ b/src/main/java/foundry/alembic/stats/item/ItemStat.java
@@ -40,7 +40,8 @@ public record ItemStat(TagOrElements.BuiltInLazy<Item> items, List<ItemModifier>
 
     public void computeAttributes(Multimap<Attribute, AttributeModifier> originalModifiers,
                                   BiPredicate<Attribute, AttributeModifier> onPut,
-                                  Consumer<Attribute> onRemove) {
+                                  Consumer<Attribute> onRemove,
+                                  EquipmentSlotType slotType) {
         AttributeContainer container = new AttributeContainer() {
             @Override
             public boolean contains(Attribute attribute) {
@@ -64,7 +65,7 @@ public record ItemStat(TagOrElements.BuiltInLazy<Item> items, List<ItemModifier>
         };
 
         for (ItemModifier data : attributeData) {
-            data.compute(container);
+            data.compute(container, slotType);
         }
     }
 

--- a/src/main/java/foundry/alembic/stats/item/modifiers/AppendItemModifier.java
+++ b/src/main/java/foundry/alembic/stats/item/modifiers/AppendItemModifier.java
@@ -2,14 +2,20 @@ package foundry.alembic.stats.item.modifiers;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.alembic.attribute.UUIDManager;
 import foundry.alembic.stats.item.ItemModifierType;
 import foundry.alembic.stats.item.ItemStat;
 import foundry.alembic.codecs.CodecUtil;
+import foundry.alembic.stats.item.slots.EquipmentSlotType;
+import foundry.alembic.util.AttributeHelper;
+import net.minecraft.Util;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.UUID;
 
 public final class AppendItemModifier implements ItemModifier {
@@ -18,16 +24,16 @@ public final class AppendItemModifier implements ItemModifier {
                     BuiltInRegistries.ATTRIBUTE.byNameCodec().fieldOf("attribute").forGetter(AppendItemModifier::getAttribute),
                     Codec.FLOAT.fieldOf("value").forGetter(AppendItemModifier::getValue),
                     CodecUtil.OPERATION_CODEC.fieldOf("operation").forGetter(AppendItemModifier::getOperation),
-                    CodecUtil.STRING_UUID.fieldOf("uuid").forGetter(AppendItemModifier::getUUID)
+                    CodecUtil.STRING_UUID.optionalFieldOf("uuid").forGetter(AppendItemModifier::getUUID)
             ).apply(instance, AppendItemModifier::new)
     );
 
     private final Attribute attribute;
     private final float value;
     private final AttributeModifier.Operation operation;
-    private final UUID uuid;
+    private final Optional<UUID> uuid;
 
-    public AppendItemModifier(Attribute attribute, float value, AttributeModifier.Operation operation, UUID uuid) {
+    public AppendItemModifier(Attribute attribute, float value, AttributeModifier.Operation operation, Optional<UUID> uuid) {
         this.attribute = attribute;
         this.value = value;
         this.operation = operation;
@@ -45,7 +51,7 @@ public final class AppendItemModifier implements ItemModifier {
     }
 
     @Override
-    public UUID getUUID() {
+    public Optional<UUID> getUUID() {
         return uuid;
     }
 
@@ -58,8 +64,14 @@ public final class AppendItemModifier implements ItemModifier {
     }
 
     @Override
-    public void compute(ItemStat.AttributeContainer container) {
-        container.put(attribute, new AttributeModifier(uuid, attribute.descriptionId, value, operation));
+    public void compute(ItemStat.AttributeContainer container, EquipmentSlotType slotType) {
+        UUID usedUuid;
+        if (slotType.getVanillaSlot() == null || slotType.getVanillaSlot().getType() == EquipmentSlot.Type.ARMOR) {
+            usedUuid = uuid.orElseGet(() -> AttributeHelper.slotUuid(slotType));
+        } else {
+            usedUuid = uuid.orElseGet(() -> AttributeHelper.baseAttributeUuid(attribute));
+        }
+        container.put(attribute, new AttributeModifier(usedUuid, attribute.descriptionId, value, operation));
     }
 
     @Override

--- a/src/main/java/foundry/alembic/stats/item/modifiers/ItemModifier.java
+++ b/src/main/java/foundry/alembic/stats/item/modifiers/ItemModifier.java
@@ -4,15 +4,17 @@ import com.mojang.serialization.Codec;
 import foundry.alembic.stats.item.ItemModifierType;
 import foundry.alembic.stats.item.ItemStat;
 import foundry.alembic.codecs.CodecUtil;
+import foundry.alembic.stats.item.slots.EquipmentSlotType;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public sealed interface ItemModifier permits AppendItemModifier, RemoveItemModifier, ReplaceItemModifier {
     Codec<ItemModifier> DISPATCH_CODEC = CodecUtil.safeDispatch(ItemModifierType.CODEC, "type", ItemModifier::getType, ItemModifierType::getCodec);
 
-    void compute(ItemStat.AttributeContainer container);
+    void compute(ItemStat.AttributeContainer container, EquipmentSlotType slotType);
 
     ItemModifierType getType();
 
@@ -21,5 +23,5 @@ public sealed interface ItemModifier permits AppendItemModifier, RemoveItemModif
 
     @Nullable Attribute getTarget();
 
-    @Nullable UUID getUUID();
+    @Nullable Optional<UUID> getUUID();
 }

--- a/src/main/java/foundry/alembic/stats/item/modifiers/RemoveItemModifier.java
+++ b/src/main/java/foundry/alembic/stats/item/modifiers/RemoveItemModifier.java
@@ -3,10 +3,12 @@ package foundry.alembic.stats.item.modifiers;
 import com.mojang.serialization.Codec;
 import foundry.alembic.stats.item.ItemModifierType;
 import foundry.alembic.stats.item.ItemStat;
+import foundry.alembic.stats.item.slots.EquipmentSlotType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public record RemoveItemModifier(Attribute target) implements ItemModifier {
@@ -15,7 +17,7 @@ public record RemoveItemModifier(Attribute target) implements ItemModifier {
             .codec();
 
     @Override
-    public void compute(ItemStat.AttributeContainer container) {
+    public void compute(ItemStat.AttributeContainer container, EquipmentSlotType slotType) {
         container.remove(target);
     }
 
@@ -35,7 +37,7 @@ public record RemoveItemModifier(Attribute target) implements ItemModifier {
     }
 
     @Override
-    public @Nullable UUID getUUID() {
-        return null;
+    public @Nullable Optional<UUID> getUUID() {
+        return Optional.empty();
     }
 }

--- a/src/main/java/foundry/alembic/stats/item/modifiers/ReplaceItemModifier.java
+++ b/src/main/java/foundry/alembic/stats/item/modifiers/ReplaceItemModifier.java
@@ -2,32 +2,37 @@ package foundry.alembic.stats.item.modifiers;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.alembic.attribute.UUIDManager;
 import foundry.alembic.stats.item.ItemModifierType;
 import foundry.alembic.stats.item.ItemStat;
 import foundry.alembic.codecs.CodecUtil;
+import foundry.alembic.stats.item.slots.EquipmentSlotType;
+import foundry.alembic.util.AttributeHelper;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public final class ReplaceItemModifier implements ItemModifier {
     public static final Codec<ReplaceItemModifier> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    BuiltInRegistries.ATTRIBUTE.byNameCodec().fieldOf("target").forGetter(replaceItemModifier -> replaceItemModifier.target),
+                    BuiltInRegistries.ATTRIBUTE.byNameCodec().fieldOf("target").forGetter(ReplaceItemModifier::getTarget),
                     Codec.FLOAT.fieldOf("value").forGetter(replaceItemModifier -> replaceItemModifier.value),
                     CodecUtil.OPERATION_CODEC.fieldOf("operation").forGetter(replaceItemModifier -> replaceItemModifier.operation),
-                    CodecUtil.STRING_UUID.fieldOf("uuid").forGetter(replaceItemModifier -> replaceItemModifier.uuid)
+                    CodecUtil.STRING_UUID.optionalFieldOf("uuid").forGetter(ReplaceItemModifier::getUUID)
             ).apply(instance, ReplaceItemModifier::new)
     );
 
     private final Attribute target;
     private final float value;
     private final AttributeModifier.Operation operation;
-    private final UUID uuid;
+    private final Optional<UUID> uuid;
 
-    public ReplaceItemModifier(Attribute target, float value, AttributeModifier.Operation operation, UUID uuid) {
+    public ReplaceItemModifier(Attribute target, float value, AttributeModifier.Operation operation, Optional<UUID> uuid) {
         this.target = target;
         this.value = value;
         this.operation = operation;
@@ -35,10 +40,16 @@ public final class ReplaceItemModifier implements ItemModifier {
     }
 
     @Override
-    public void compute(ItemStat.AttributeContainer container) {
+    public void compute(ItemStat.AttributeContainer container, EquipmentSlotType slotType) {
         if (container.contains(target)) {
             container.remove(target);
-            container.put(target, new AttributeModifier(uuid, target.descriptionId, value, operation));
+            UUID usedUuid;
+            if (slotType.getVanillaSlot() == null || slotType.getVanillaSlot().getType() == EquipmentSlot.Type.ARMOR) {
+                usedUuid = uuid.orElseGet(() -> AttributeHelper.slotUuid(slotType));
+            } else {
+                usedUuid = uuid.orElseGet(() -> AttributeHelper.baseAttributeUuid(target));
+            }
+            container.put(target, new AttributeModifier(usedUuid, target.descriptionId, value, operation));
         }
     }
 
@@ -58,7 +69,7 @@ public final class ReplaceItemModifier implements ItemModifier {
     }
 
     @Override
-    public @Nullable UUID getUUID() {
+    public @Nullable Optional<UUID> getUUID() {
         return uuid;
     }
 }

--- a/src/main/java/foundry/alembic/util/AttributeHelper.java
+++ b/src/main/java/foundry/alembic/util/AttributeHelper.java
@@ -1,12 +1,18 @@
 package foundry.alembic.util;
 
+import foundry.alembic.attribute.UUIDFactory;
+import foundry.alembic.attribute.UUIDManager;
 import foundry.alembic.attribute.UUIDSavedData;
+import foundry.alembic.stats.item.slots.EquipmentSlotType;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.level.Level;
 
 import java.util.UUID;
 
@@ -14,9 +20,8 @@ public class AttributeHelper {
     public static void addOrModifyModifier(LivingEntity livingEntity, Attribute attribute, ResourceLocation modifierId, double bonus) {
         if (livingEntity.level() instanceof ServerLevel serverLevel) {
             AttributeInstance instance = livingEntity.getAttribute(attribute);
-            UUIDSavedData savedData = UUIDSavedData.getOrLoad(serverLevel.getServer());
             if (instance != null) {
-                addOrModifyModifier(instance, modifierId, savedData.getOrCreate(modifierId), bonus);
+                addOrModifyModifier(instance, modifierId, UUIDFactory.getOrCreate(serverLevel, modifierId), bonus);
             }
         }
     }
@@ -29,6 +34,27 @@ public class AttributeHelper {
             instance.removePermanentModifier(modifierUuid);
             instance.addPermanentModifier(new AttributeModifier(modifierUuid, modifierId.toString(), modifier.getAmount()+bonus, AttributeModifier.Operation.ADDITION));
         }
+    }
+
+//    public static UUID attributeUuid(Level level, Attribute attribute, InteractionHand hand) {
+//        ResourceLocation attributeId = BuiltInRegistries.ATTRIBUTE.getKey(attribute);
+//        if (hand == InteractionHand.MAIN_HAND) {
+//            return UUIDFactory.getOrCreate(level, attributeId);
+//        } else {
+//            return UUIDFactory.getOrCreate(level, attributeId.withSuffix("_offhand"));
+//        }
+//    }
+//
+//    public static UUID baseAttributeUuid(Level level, Attribute attribute) {
+//        return attributeUuid(level, attribute, InteractionHand.MAIN_HAND);
+//    }
+
+    public static UUID baseAttributeUuid(Attribute attribute) {
+        return UUIDManager.getOrCreate(BuiltInRegistries.ATTRIBUTE.getKey(attribute));
+    }
+
+    public static UUID slotUuid(EquipmentSlotType slotType) {
+        return UUIDManager.getOrCreate(new ResourceLocation(slotType.getName()));
     }
 
 //    public static double applyModifiersTo(AttributeInstance instance, double num) {

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_boots.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_boots.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "d8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "FEET"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_chestplate.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_chestplate.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 3,
-      "operation": "ADDITION",
-      "uuid": "c8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "CHEST"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_helmet.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_helmet.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "b8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "HEAD"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_leggings.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/diamond_leggings.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "a8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "LEGS"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_axe.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_axe.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_boots.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_boots.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "f4c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "FEET"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_chestplate.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_chestplate.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 6,
-      "operation": "ADDITION",
-      "uuid": "f3c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "CHEST"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_helmet.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_helmet.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 4,
-      "operation": "ADDITION",
-      "uuid": "f2c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "HEAD"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_hoe.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_hoe.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 0.5,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_leggings.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_leggings.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage.resistance",
       "value": 5,
-      "operation": "ADDITION",
-      "uuid": "f1c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "LEGS"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_pickaxe.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_pickaxe.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_shovel.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_shovel.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_sword.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/golden_sword.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_boots.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_boots.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:fire_damage.resistance",
       "value": 4,
-      "operation": "ADDITION",
-      "uuid": "f8e3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "FEET"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_chestplate.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_chestplate.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:fire_damage.resistance",
       "value": 4,
-      "operation": "ADDITION",
-      "uuid": "f8f3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "CHEST"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_helmet.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_helmet.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:fire_damage.resistance",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "f8b3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "HEAD"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_leggings.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/netherite_leggings.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:fire_damage.resistance",
       "value": 3,
-      "operation": "ADDITION",
-      "uuid": "f8d3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "LEGS"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/redstone_torch.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/redstone_torch.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:alchemical_damage",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/soul_torch.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/soul_torch.json
@@ -5,15 +5,13 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 0.5,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     },
     {
       "type": "append",
       "attribute": "alembic:fire_damage",
       "value": 0.5,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/torch.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/torch.json
@@ -5,8 +5,7 @@
       "type": "append",
       "attribute": "alembic:fire_damage",
       "value": 1,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"

--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/trident.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/item_stats/trident.json
@@ -5,15 +5,13 @@
       "type": "append",
       "attribute": "alembic:arcane_damage",
       "value": 2,
-      "operation": "ADDITION",
-      "uuid": "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+      "operation": "ADDITION"
     },
     {
       "type": "replace",
       "target": "minecraft:generic.attack_damage",
       "value": 6,
-      "operation": "ADDITION",
-      "uuid": "CB3F55D3-645C-4F38-A497-9C13A33DB5CF"
+      "operation": "ADDITION"
     }
   ],
   "equipment_slot": "MAINHAND"


### PR DESCRIPTION
This way, uuids are purely based on resource locations and are unique only through them. Allows us to make the "uuid" field optional. If a uuid is specified in an item stat modifier, it is no longer considered a "base" attribute and is a regular blue modifier.