### PR TITLE
Update physical_damage.json

### DIFF
--- a/src/main/resources/defaultresources/alembic_pack/alembic/attribute_sets/physical_damage.json
+++ b/src/main/resources/defaultresources/alembic_pack/alembic/attribute_sets/physical_damage.json
@@ -1,5 +1,9 @@
 {
-  "damage_attribute": "minecraft:generic.attack_damage",
+  "damage_attribute": {
+    "base": 0,
+    "min": 0,
+    "max": 1024
+  },
   "shielding_attribute": {
     "base": 0,
     "min": 0,


### PR DESCRIPTION
Please.
Having the damage attribute as `"minecraft:generic.attack_damage"` is causing mobs to deal an incorrect amount of damage. Also removing the `"minecraft:player_attack"` in the base overrides is causing player damage not to translate into alembic damage.