### PR TITLE
Update base_overrides.json

### DIFF
--- a/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/overrides/base_overrides.json
+++ b/src/main/resources/data/alembic/datapacks/alembic_default/data/alembic/alembic/overrides/base_overrides.json
@@ -25,6 +25,7 @@
     "alembic:guardian_beam": {"arcane_damage": 1.0},
     "minecraft:arrow": {"physical_damage": 1.0},
     "minecraft:thrown": {"physical_damage": 1.0},
-    "minecraft:fall": {"true_damage": 1.0}
+    "minecraft:fall": {"true_damage": 1.0},
+    "minecraft:player_attack": {"physical_damage": 1.0}
   }
 }


### PR DESCRIPTION
Re-added `"minecraft:player_attack": {"physical_damage": 1.0}`. This and the change to `attribute_sets/physical_damage.json` should fix the problem of mobs doing incorrect damage and player's should now be able to change the type of damage they do